### PR TITLE
Use system alarm sound by default

### DIFF
--- a/android/alarmclock/.gitignore
+++ b/android/alarmclock/.gitignore
@@ -4,3 +4,5 @@
 /gradle
 /gradlew
 /local.properties
+/.idea/
+/gradle/

--- a/android/alarmclock/build.gradle
+++ b/android/alarmclock/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
     }
 }
 

--- a/android/alarmclock/klock/src/main/java/com/angrydoughnuts/android/alarmclock/AlarmNotificationService.java
+++ b/android/alarmclock/klock/src/main/java/com/angrydoughnuts/android/alarmclock/AlarmNotificationService.java
@@ -400,7 +400,7 @@ public class AlarmNotificationService extends Service {
       } catch (IOException e) {
         Log.e(TAG, "Failed loading tone: " + e.toString());
         try {
-          player.setDataSource(c, Settings.System.DEFAULT_NOTIFICATION_URI);
+          player.setDataSource(c, Settings.System.DEFAULT_ALARM_ALERT_URI);
         } catch (IOException e2) {
           Log.e(TAG, "Failed loading backup tone: " + e2.toString());
         }

--- a/android/alarmclock/klock/src/main/java/com/angrydoughnuts/android/alarmclock/AlarmOptions.java
+++ b/android/alarmclock/klock/src/main/java/com/angrydoughnuts/android/alarmclock/AlarmOptions.java
@@ -91,7 +91,7 @@ public class AlarmOptions extends android.app.DialogFragment {
           .build());
       try {
         player.setDataSource(
-            getContext(), Settings.System.DEFAULT_NOTIFICATION_URI);
+            getContext(), Settings.System.DEFAULT_ALARM_ALERT_URI);
         player.prepare();
       } catch (IOException e) {}
     }

--- a/android/alarmclock/klock/src/main/java/com/angrydoughnuts/android/alarmclock/DbUtil.java
+++ b/android/alarmclock/klock/src/main/java/com/angrydoughnuts/android/alarmclock/DbUtil.java
@@ -19,6 +19,7 @@ import android.content.ContentUris;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
+import android.provider.Settings;
 
 import java.util.Calendar;
 
@@ -113,7 +114,7 @@ public class DbUtil {
     public final int volume_time;
 
     private static final Uri TONE_URL_DEFAULT =
-      android.provider.Settings.System.DEFAULT_NOTIFICATION_URI;
+      android.provider.Settings.System.DEFAULT_ALARM_ALERT_URI;
     private static final int SNOOZE_DEFAULT = 10;
     private static final boolean VIBRATE_DEFAULT = false;
     private static final int VOLUME_STARTING_DEFAULT = 0;
@@ -177,7 +178,7 @@ public class DbUtil {
 
     private Settings(Context c) {
       tone_url = TONE_URL_DEFAULT;
-      tone_name = c.getString(R.string.system_default);
+      tone_name = c.getString(R.string.system_default_alarm);
       snooze = SNOOZE_DEFAULT;
       vibrate = VIBRATE_DEFAULT;
       volume_starting = VOLUME_STARTING_DEFAULT;

--- a/android/alarmclock/klock/src/main/java/com/angrydoughnuts/android/alarmclock/MediaPicker.java
+++ b/android/alarmclock/klock/src/main/java/com/angrydoughnuts/android/alarmclock/MediaPicker.java
@@ -92,8 +92,13 @@ public class MediaPicker extends android.app.DialogFragment {
               public View createTabContent(String tag) {
                 return newList(
                     Audio.Media.INTERNAL_CONTENT_URI, new ExtraEntry[] {
+                      new ExtraEntry(Settings.System.DEFAULT_ALARM_ALERT_URI,
+                                      getString(R.string.system_default_alarm)),
                       new ExtraEntry(Settings.System.DEFAULT_NOTIFICATION_URI,
-                                     getString(R.string.system_default)) });
+                                      getString(R.string.system_default_notification)),
+                      new ExtraEntry(Settings.System.DEFAULT_RINGTONE_URI,
+                                      getString(R.string.system_default_ringtone)) }
+                );
               }
             }));
     t.setOnTabChangedListener(new android.widget.TabHost.OnTabChangeListener() {

--- a/android/alarmclock/klock/src/main/res/values/strings.xml
+++ b/android/alarmclock/klock/src/main/res/values/strings.xml
@@ -48,6 +48,9 @@
   <string name="weekdays">Weekdays</string>
   <string name="weekends">Weekends</string>
   <string name="system_default">System default</string>
+  <string name="system_default_alarm">System default alarm</string>
+  <string name="system_default_notification">System default notification</string>
+  <string name="system_default_ringtone">System default ringtone</string>
   <string name="internal">Internal</string>
   <string name="artists">Artists</string>
   <string name="songs">Songs</string>


### PR DESCRIPTION
Instead of notification ringtone, use the system alarm ringtone by
default. "Internal" media picker offer the three system-wide sound types
: alarm, notification or ringtone.

See issue #144 