### PR TITLE
Disable snooze by setting snooze time to zero.

### DIFF
--- a/android/alarmclock/klock/src/main/java/com/angrydoughnuts/android/alarmclock/AlarmNotificationActivity.java
+++ b/android/alarmclock/klock/src/main/java/com/angrydoughnuts/android/alarmclock/AlarmNotificationActivity.java
@@ -91,6 +91,10 @@ public class AlarmNotificationActivity extends Activity {
             finish();
           }
         });
+    if (snooze==0){
+        findViewById(R.id.snooze_alarm).setVisibility(View.INVISIBLE);
+        findViewById(R.id.snooze_bar).setVisibility(View.INVISIBLE);
+    }
   }
 
   @Override

--- a/android/alarmclock/klock/src/main/java/com/angrydoughnuts/android/alarmclock/AlarmOptions.java
+++ b/android/alarmclock/klock/src/main/java/com/angrydoughnuts/android/alarmclock/AlarmOptions.java
@@ -475,26 +475,24 @@ public class AlarmOptions extends android.app.DialogFragment {
       final ViewGroup edit_snooze = newItem(c);
       addView(edit_snooze);
       setImage(edit_snooze, R.drawable.ic_snooze);
-      setText(edit_snooze, c.getString(R.string.minute_abbriv, s.snooze));
+      setText(edit_snooze, s.snooze==0?c.getString(R.string.off):c.getString(R.string.minute_abbriv, s.snooze));
       final SeekBar snooze_bar = new SeekBar(c);
       setView(edit_snooze, snooze_bar, 1.0f);
-      // Range 1 - 60 increments of 1.
-      snooze_bar.setMax(59);
-      snooze_bar.setProgress(s.snooze - 1);
+      // Range 0 - 60 increments of 1. 0 means off
+      snooze_bar.setMax(60);
+      snooze_bar.setProgress(s.snooze);
       snooze_bar.setOnSeekBarChangeListener(
           new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar s, int prog, boolean user) {
-              final int snooze = prog + 1;
-              setText(edit_snooze, c.getString(R.string.minute_abbriv, snooze));
+              setText(edit_snooze, prog==0?c.getString(R.string.off):c.getString(R.string.minute_abbriv, prog));
             }
             @Override
             public void onStartTrackingTouch(SeekBar s) {}
             @Override
             public void onStopTrackingTouch(SeekBar s) {
-              final int snooze = s.getProgress() + 1;
               ContentValues val = new ContentValues();
-              val.put(AlarmClockProvider.SettingsEntry.SNOOZE, snooze);
+              val.put(AlarmClockProvider.SettingsEntry.SNOOZE, s.getProgress());
               c.getContentResolver().update(settings, val, null, null);
             }
           });

--- a/android/alarmclock/klock/src/main/res/layout/notification.xml
+++ b/android/alarmclock/klock/src/main/res/layout/notification.xml
@@ -4,6 +4,7 @@
               android:layout_width="fill_parent"
               android:layout_height="fill_parent">
   <LinearLayout
+      android:id="@+id/snooze_bar"
       android:orientation="horizontal"
       android:layout_weight="1"
       android:layout_width="fill_parent"

--- a/android/alarmclock/klock/src/main/res/values-de/strings.xml
+++ b/android/alarmclock/klock/src/main/res/values-de/strings.xml
@@ -8,6 +8,7 @@
   <string name="alarm_tone">Weckton</string>
   <string name="fade_description">Von %1$d%% bis %2$d%% über %3$d Sekunden</string>
   <string name="ok">OK</string>
+  <string name="off">aus</string>
   <string name="cancel">Abbrechen</string>
   <string name="delete">Löschen</string>
   <string name="snooze">SNOOZE</string>

--- a/android/alarmclock/klock/src/main/res/values/strings.xml
+++ b/android/alarmclock/klock/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
   <string name="alarm_tone">Alarm tone</string>
   <string name="fade_description">%1$d%% to %2$d%% over %3$d seconds</string>
   <string name="ok">OK</string>
+  <string name="off">off</string>
   <string name="cancel">Cancel</string>
   <string name="done">Done</string>
   <string name="snooze">SNOOZE</string>


### PR DESCRIPTION
This adds the possibility to hide all snooze related buttons from the alarm screen by setting the snooze time to zero.

I have done this and the other pull request (dismiss alarm with button instead of a slider) for myself, but in case it is useful for other users feel free to merge them.